### PR TITLE
Gestion des fichiers de config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ app/node_modules/
 dist/
 node_modules/
 models/
-
+config/secret
+app/config/secret

--- a/app/config/app.json
+++ b/app/config/app.json
@@ -1,0 +1,5 @@
+{
+  "development": {
+    "serverURL": "http://localhost:3001/"
+  }
+}

--- a/app/src/application/actions.tsx
+++ b/app/src/application/actions.tsx
@@ -1,9 +1,7 @@
 import {Action, Concept} from './types'
 
-const DB_CONFIG = require('../../../config/database.json')
-
-const serverUrl = (process.env.NODE_ENV == 'production') ? DB_CONFIG['production']['url'] : DB_CONFIG['development']['url']
-
+import config from './config'
+const serverUrl = config('app').serverURL
 export function fetchConcept(url: string, container: string): Action {
     return {
         type: 'FETCH_CONCEPT',

--- a/app/src/application/config.js
+++ b/app/src/application/config.js
@@ -1,0 +1,26 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const ENV = process.env.NODE_ENV || "development";
+const path = require("path");
+
+
+const secretContext = require.context('./../../config/secret/', false, /\.json?$/)
+const publicContext = require.context('./../../config/', false, /\.json?$/)
+
+/**
+    Accesses the proper config file.
+    Check for config under /config/secret/config.json
+*/
+function properConfig(configName) {
+    const secretInclude = secretContext.keys().filter((key) => key.includes(configName + '.json'))[0]
+    if(secretContext(secretInclude)[ENV]) {
+        return secretContext(secretInclude)[ENV]
+
+    } else {
+        const publicInclude = publicContext.keys().filter((key) => key.includes(configName + '.json'))[0]
+        return publicContext(publicInclude)[ENV]
+    }
+}
+
+
+exports.default = properConfig;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -4,7 +4,8 @@
         "module": "commonjs",
         "noImplicitAny": true,
         "experimentalDecorators": true,
-        "target": "es6"
+        "target": "es6",
+        "allowJs": true
     },
     "include": [
         "**/*.tsx"

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = {
         filename: 'app.bundle.js',
     },
     resolve: {
-        extensions: ['.js', '.ts', '.tsx']
+        extensions: ['.js', '.ts', '.tsx', '.json']
     },
     module: {
         loaders: [

--- a/config.js
+++ b/config.js
@@ -2,20 +2,33 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const ENV = process.env.NODE_ENV || "development";
 const path = require("path");
+const fs = require('fs')
 
 /**
     Accesses the proper config file.
     Check for config under /config/secret/config.json
 */
 function properConfig(configFile) {
-    console.log(path.join(__dirname + "/secret/" + configFile + '.json'))
-    const secretConfig = require(path.join(__dirname + "/config/secret/" + configFile + '.json'))[ENV];
-    if (!secretConfig) {
-        const simpleConfig = require(path.join(__dirname + "/config/" + configFile + '.json'))[ENV];
-        return simpleConfig;
+
+    const secretPath = path.join(__dirname, 'config/secret', configFile)
+    const publicPath = path.join(__dirname, 'config', configFile)
+    if(fs.existsSync(secretPath + '.json')) {
+        const secretConfig = require(secretPath)
+        if(secretConfig[ENV]) {
+            return secretConfig[ENV]
+        }
     }
-    else {
-        return secretConfig;
+
+    if (fs.existsSync(publicPath + '.json')) {
+        const publicConfig = require(publicPath)
+        if (publicConfig[ENV]) {
+            return publicConfig[ENV]
+        } else {
+            console.log("No configuration available for specified context")
+        }
     }
+
+
+
 }
 exports.default = properConfig;

--- a/config.js
+++ b/config.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const ENV = process.env.NODE_ENV || "development";
+const path = require("path");
+
+/**
+    Accesses the proper config file.
+    Check for config under /config/secret/config.json
+*/
+function properConfig(configFile) {
+    console.log(path.join(__dirname + "/secret/" + configFile + '.json'))
+    const secretConfig = require(path.join(__dirname + "/config/secret/" + configFile + '.json'))[ENV];
+    if (!secretConfig) {
+        const simpleConfig = require(path.join(__dirname + "/config/" + configFile + '.json'))[ENV];
+        return simpleConfig;
+    }
+    else {
+        return secretConfig;
+    }
+}
+exports.default = properConfig;

--- a/config/app.json
+++ b/config/app.json
@@ -1,0 +1,6 @@
+//Specific config relative to app and backend
+{
+  "development": {
+    "serverURL": "localhost:3001"
+  }
+}

--- a/config/database.json
+++ b/config/database.json
@@ -1,20 +1,5 @@
 {
-    "development": {
-        "url": "http://localhost:3001/",
-        "username": "root",
-        "password": "root",
-        "database": "orion",
-        "host": "localhost",
-        "dialect": "postgres"
-    },
-    "production": {
-        "url": "http://09f503be.ngrok.io/",
-        "username": "root",
-        "password": "root",
-        "database": "orion",
-        "host": "localhost",
-        "dialect": "postgres"
-    },
+    
     "ci": {
         "username": "ubuntu",
         "password": null,

--- a/data/schema.js
+++ b/data/schema.js
@@ -1,8 +1,7 @@
 const path = require('path')
 
 const Sequelize = require('sequelize')
-const ENV = process.env.NODE_ENV || 'development';
-const DB_CONFIG = require(path.join(__dirname, '/../config/database.json'))[ENV]
+const DB_CONFIG = require(path.join(__dirname, '../config')).default('database')
 
 const possibleModules = [
     'timeseries',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -240,7 +240,7 @@ gulp.task('build-tests', () => {
         .pipe(gulp.dest(DIST_FOLD))
 })
 
-gulp.task('run-test-all', ['build-tests', 'copy-config', 'copy-secret', 'copy-model-definition'], () => {
+gulp.task('run-test-all', ['build-tests', 'copy-config', 'copy-model-definition'], () => {
     return gulp.src('.')
         .pipe(mocha())
 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,10 +14,11 @@ const sourcemaps = require('gulp-sourcemaps')
 const SequelizeAuto = require('sequelize-auto')
 const Sequelize = require('sequelize')
 const ENV = process.env.NODE_ENV || 'development';
-const DB_CONFIG = require(path.join(__dirname, '/config/database.json'))[ENV]
+const DB_CONFIG = require('./config').default('database')
 
 const DIST_FOLD = path.join(__dirname, '/dist/')
 const CONFIG_FOLD = path.join(__dirname, '/config/')
+const SECRET_FOLD = path.join(__dirname, '/secret')
 const DATA_FOLD = path.join(__dirname, '/data/')
 
 const MODELS_FOLD = path.join(__dirname, '/models/')
@@ -239,7 +240,7 @@ gulp.task('build-tests', () => {
         .pipe(gulp.dest(DIST_FOLD))
 })
 
-gulp.task('run-test-all', ['build-tests', 'copy-config', 'copy-model-definition'], () => {
+gulp.task('run-test-all', ['build-tests', 'copy-config', 'copy-secret', 'copy-model-definition'], () => {
     return gulp.src('.')
         .pipe(mocha())
 })
@@ -273,6 +274,12 @@ gulp.task('copy-config', () => {
     return gulp.src(CONFIG_FOLD + '/**/*.json')
         .pipe(gulp.dest(path.join(DIST_FOLD, '/config')))
 })
+
+gulp.task('copy-secret', () => {
+  return gulp.src(SECRET_FOLD + '/**/*.json').pipe(gulp.dest(path.join(DIST_FOLD, '/secret')))
+})
+
+
 
 gulp.task('copy-model-definition', () => {
     return gulp.src(DATA_FOLD + '/*.js')

--- a/server/gulpfile.js
+++ b/server/gulpfile.js
@@ -16,13 +16,18 @@ gulp.task('copy-config', (callback) => {
         .pipe(gulp.dest(path.join(DIR_FOLD, '/config')))
 })
 
+gulp.task('copy-secret', (callback) => {
+  return gulp.src(path.join(__dirname, '/../secret/*'))
+        .pipe(gulp.dest(path.join(DIR_FOLD, '/secret')))
+})
+
 gulp.task('build-models', (callback) => {
     return gulp.src(path.join(__dirname, '/../models/*'))
         .pipe(ts())
         .pipe(gulp.dest(path.join(DIR_FOLD, '/models')))
 })
 
-gulp.task('build', ['build-models', 'copy-config'],  (callback) => {
+gulp.task('build', ['build-models', 'copy-config', 'copy-secret'],  (callback) => {
     return tsProject.src()
         .pipe(sourcemaps.init())
         .pipe(tsProject())

--- a/server/gulpfile.js
+++ b/server/gulpfile.js
@@ -16,18 +16,13 @@ gulp.task('copy-config', (callback) => {
         .pipe(gulp.dest(path.join(DIR_FOLD, '/config')))
 })
 
-gulp.task('copy-secret', (callback) => {
-  return gulp.src(path.join(__dirname, '/../secret/*'))
-        .pipe(gulp.dest(path.join(DIR_FOLD, '/secret')))
-})
-
 gulp.task('build-models', (callback) => {
     return gulp.src(path.join(__dirname, '/../models/*'))
         .pipe(ts())
         .pipe(gulp.dest(path.join(DIR_FOLD, '/models')))
 })
 
-gulp.task('build', ['build-models', 'copy-config', 'copy-secret'],  (callback) => {
+gulp.task('build', ['build-models', 'copy-config'],  (callback) => {
     return tsProject.src()
         .pipe(sourcemaps.init())
         .pipe(tsProject())

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -5,9 +5,9 @@
 
 import * as Sequelize from 'sequelize'
 import * as path from 'path'
-const ENV = process.env.NODE_ENV || 'development';
-const DB_CONFIG = require(path.join(__dirname, '/../../config/database.json'))[ENV]
-
+import config from './../../../config'
+const DB_CONFIG = config('database')
+console.log(process.env.PWD)
 // Start a new Sequelize instance which will be globally used
 // over the backend.
 export const sequelize = new Sequelize(

--- a/test/database.ts
+++ b/test/database.ts
@@ -1,6 +1,6 @@
 import {assert} from 'chai'
 
-import * as schema from '../data/schema'
+import * as schema from '../../data/schema'
 import {
     concept_nodesAttribute,
 } from '../models/db'


### PR DESCRIPTION
Salut !
Voici une petite PR qui m'aura posé quelque difficulté.
Il s'agit de la gestion des fichiers de configuration du projet.

### La gestion des fichiers de configuration
Le problème qui se posait était que l'on ne souhaitait pas avoir les identifiants de la base de donnée sur le repo. Cependant, les configurations doivent être apparente dans le projet pour ce qui concerne le CI ou les autres configurations non sensible.

J'ai implémenté du coup une petite API pour gérer ça.
Désormais, les fichiers de configurations sont rangés dans des dossiers `config/` et `config/secret/`.
`config/secret/` étant dans le `.gitignore`, on peut y ranger tous les fichiers de configuration sensible. 
Les autres fichiers de configurations sont simplement rangés dans `config/` et apparaissent sur le repo.

_Exemple_ : 
On peut imaginer pour `database.json` une arborescence comme ça : 
```
config/
|_database.json
|_secret/
|__database.json
```
Le premier `database.json` contient donc les informations non sensibles utiles au CI/exemples tandis que celui rangé dans `secret/` contiendra les identifiants pour les ordinateurs ou le PI.

Dans le code, c'est plutôt transparent, j'ai fait les modifications dans tous les fichiers qui avaient besoin de config et ça donne ça : 
```js
import config from './config'
let credentials = config('database')
```
**C'est la fonction dans `config.js` qui se charge de vérifier si un fichier nommé `database.json` existe bien dans `config/secret/` selon l'environnement et qui va le piocher dans `config/` à défaut**

### Séparation des fichiers de config du backend/data vs frontend/app

Autre petit point : 

⚠️ Les configurations par l'app sont désormais dans `app/config` ⚠️
C'est assez important car on avait une grosse faille de sécurité en mélangeant les fichiers de config concernant l'app et ceux des data/backend (On faisait apparaître les identifiants de la DB dans la console chrome).

Il y a 2 fichiers `config.js` qui font la même chose mais qui ne sont pas codé de la même façon.
Le premier est à la racine et utilise l'API `fs` pour vérifier l'existence des fichiers de config.
Le second, qui sert au frontend/app, utilise une fonction spéciale de webpack qui sert à faire des `require()` conditionnel pour n'importer que les fichiers de config dont on a besoin pour l'app.
